### PR TITLE
Support `llm -c` (continue conversation) for DevinModel

### DIFF
--- a/llm_devin/_devin.py
+++ b/llm_devin/_devin.py
@@ -82,28 +82,61 @@ class DevinModel(llm.KeyModel):
         finally:
             self._teardown_debug_logging(handler)
 
+    def _get_previous_session_id(self, conversation):
+        if conversation is None:
+            return None
+        responses = getattr(conversation, "responses", None)
+        if not responses:
+            return None
+        prev_response_json = responses[-1].response_json
+        if not isinstance(prev_response_json, dict):
+            return None
+        return prev_response_json.get("session_id")
+
     def _execute(self, prompt, stream, response, conversation, key):
         org_id = self._org_id()
         headers = {"Authorization": f"Bearer {key}"}
-        request_json = {"prompt": prompt.prompt}
-        logger.debug("Request JSON: %s", request_json)
-        create_session_response = httpx.post(
-            f"{self.BASE_URL}/organizations/{org_id}/sessions",
-            headers=headers,
-            json=request_json,
-            timeout=TIMEOUT,
-        )
-        create_session_response.raise_for_status()
 
-        create_session_data = create_session_response.json()
-        logger.debug(
-            "create_session response",
-            extra={"data": create_session_data},
-        )
-        session_id = create_session_data["session_id"]
-        print_immediately("Devin URL:", create_session_data["url"])
+        previous_session_id = self._get_previous_session_id(conversation)
 
-        poll_state: dict = {"cursor": None}
+        if previous_session_id is not None:
+            session_id = previous_session_id
+            logger.debug(
+                "Continuing session %s", session_id,
+            )
+            send_message_response = httpx.post(
+                f"{self.BASE_URL}/organizations/{org_id}/sessions/{session_id}/messages",
+                headers=headers,
+                json={"message": prompt.prompt},
+                timeout=TIMEOUT,
+            )
+            send_message_response.raise_for_status()
+
+            prev_cursor = None
+            prev_response_json = conversation.responses[-1].response_json
+            if isinstance(prev_response_json, dict):
+                prev_cursor = prev_response_json.get("end_cursor")
+            poll_state: dict = {"cursor": prev_cursor}
+        else:
+            request_json = {"prompt": prompt.prompt}
+            logger.debug("Request JSON: %s", request_json)
+            create_session_response = httpx.post(
+                f"{self.BASE_URL}/organizations/{org_id}/sessions",
+                headers=headers,
+                json=request_json,
+                timeout=TIMEOUT,
+            )
+            create_session_response.raise_for_status()
+
+            create_session_data = create_session_response.json()
+            logger.debug(
+                "create_session response",
+                extra={"data": create_session_data},
+            )
+            session_id = create_session_data["session_id"]
+            print_immediately("Devin URL:", create_session_data["url"])
+            poll_state = {"cursor": None}
+
         seen_event_ids: set[str] = set()
 
         devin_messages: list[str] = []
@@ -133,6 +166,11 @@ class DevinModel(llm.KeyModel):
                 }:
                     break
             time.sleep(5)
+
+        response.response_json = {
+            "session_id": session_id,
+            "end_cursor": poll_state["cursor"],
+        }
 
     def _get_session(self, headers, org_id, session_id):
         session_response = httpx.get(

--- a/llm_devin/_devin.py
+++ b/llm_devin/_devin.py
@@ -113,10 +113,12 @@ class DevinModel(llm.KeyModel):
                 )
                 send_message_response.raise_for_status()
             except httpx.HTTPStatusError as ex:
-                raise llm.ModelError(
-                    "The previous Devin session is invalid or expired. "
-                    "Please start a new conversation."
-                ) from ex
+                if ex.response.status_code in {404, 410}:
+                    raise llm.ModelError(
+                        "The previous Devin session is invalid or expired. "
+                        "Please start a new conversation."
+                    ) from ex
+                raise
 
             prev_cursor = None
             prev_response_json = conversation.responses[-1].response_json

--- a/llm_devin/_devin.py
+++ b/llm_devin/_devin.py
@@ -104,13 +104,19 @@ class DevinModel(llm.KeyModel):
             logger.debug(
                 "Continuing session %s", session_id,
             )
-            send_message_response = httpx.post(
-                f"{self.BASE_URL}/organizations/{org_id}/sessions/{session_id}/messages",
-                headers=headers,
-                json={"message": prompt.prompt},
-                timeout=TIMEOUT,
-            )
-            send_message_response.raise_for_status()
+            try:
+                send_message_response = httpx.post(
+                    f"{self.BASE_URL}/organizations/{org_id}/sessions/{session_id}/messages",
+                    headers=headers,
+                    json={"message": prompt.prompt},
+                    timeout=TIMEOUT,
+                )
+                send_message_response.raise_for_status()
+            except httpx.HTTPStatusError as ex:
+                raise llm.ModelError(
+                    "The previous Devin session is invalid or expired. "
+                    "Please start a new conversation."
+                ) from ex
 
             prev_cursor = None
             prev_response_json = conversation.responses[-1].response_json

--- a/tests/test_devin.py
+++ b/tests/test_devin.py
@@ -854,3 +854,49 @@ def test_continue_conversation_uses_previous_cursor(monkeypatch, respx_mock):
     )
 
     assert actual == ["Response after cursor"]
+    assert response.response_json == {
+        "session_id": "devin-test-session",
+        "end_cursor": "cursor-new",
+    }
+
+
+@respx.mock(assert_all_called=True, assert_all_mocked=True)
+def test_continue_conversation_invalid_session_raises_model_error(
+    monkeypatch, respx_mock
+):
+    monkeypatch.setenv("LLM_DEVIN_ORG_ID", ORG_ID)
+
+    respx_mock.post(
+        f"{BASE_URL}/organizations/{ORG_ID}/sessions/devin-deleted-session/messages",
+        headers__contains={"Authorization": "Bearer test-api-key"},
+        json__eq={"message": "Follow up"},
+    ).mock(
+        return_value=httpx.Response(404, json={"error": "session not found"})
+    )
+
+    sut = DevinModel()
+    prompt = MagicMock()
+    prompt.prompt = "Follow up"
+    prompt.options.debug = False
+
+    prev_response = MagicMock()
+    prev_response.response_json = {
+        "session_id": "devin-deleted-session",
+        "end_cursor": "cursor-old",
+    }
+    conversation = MagicMock()
+    conversation.responses = [prev_response]
+
+    with pytest.raises(
+        llm.ModelError,
+        match="The previous Devin session is invalid or expired",
+    ):
+        list(
+            sut.execute(
+                prompt,
+                stream=False,
+                response=MagicMock(),
+                conversation=conversation,
+                key="test-api-key",
+            )
+        )

--- a/tests/test_devin.py
+++ b/tests/test_devin.py
@@ -629,3 +629,228 @@ def test_duplicate_messages_are_deduplicated(monkeypatch, respx_mock):
         )
 
     assert actual == ["Working on it", "\nAll done"]
+
+
+@respx.mock(assert_all_called=True, assert_all_mocked=True)
+def test_new_session_stores_session_id(monkeypatch, respx_mock):
+    monkeypatch.setenv("LLM_DEVIN_ORG_ID", ORG_ID)
+
+    respx_mock.post(
+        f"{BASE_URL}/organizations/{ORG_ID}/sessions",
+        headers__contains={"Authorization": "Bearer test-api-key"},
+        json__eq={"prompt": "Hello"},
+    ).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "session_id": "devin-test-session",
+                "url": "https://app.devin.ai/sessions/devin-test-session",
+                "status": "running",
+            },
+        )
+    )
+    respx_mock.get(
+        f"{BASE_URL}/organizations/{ORG_ID}/sessions/devin-test-session",
+        headers__contains={"Authorization": "Bearer test-api-key"},
+    ).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "session_id": "devin-test-session",
+                "status": "running",
+                "status_detail": "finished",
+            },
+        )
+    )
+    respx_mock.get(
+        f"{BASE_URL}/organizations/{ORG_ID}/sessions/devin-test-session/messages",
+        headers__contains={"Authorization": "Bearer test-api-key"},
+    ).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "items": [
+                    {
+                        "event_id": "evt-1",
+                        "source": "devin",
+                        "message": "Hi!",
+                        "created_at": 1000,
+                    },
+                ],
+                "end_cursor": "cursor-1",
+                "has_next_page": False,
+            },
+        )
+    )
+
+    sut = DevinModel()
+    prompt = MagicMock()
+    prompt.prompt = "Hello"
+    prompt.options.debug = False
+    response = MagicMock()
+
+    list(
+        sut.execute(
+            prompt,
+            stream=False,
+            response=response,
+            conversation=None,
+            key="test-api-key",
+        )
+    )
+
+    assert response.response_json == {
+        "session_id": "devin-test-session",
+        "end_cursor": "cursor-1",
+    }
+
+
+@respx.mock(assert_all_called=True, assert_all_mocked=True)
+def test_continue_conversation(monkeypatch, respx_mock):
+    monkeypatch.setenv("LLM_DEVIN_ORG_ID", ORG_ID)
+
+    respx_mock.post(
+        f"{BASE_URL}/organizations/{ORG_ID}/sessions/devin-test-session/messages",
+        headers__contains={"Authorization": "Bearer test-api-key"},
+        json__eq={"message": "Follow up question"},
+    ).mock(
+        return_value=httpx.Response(200, json={})
+    )
+    respx_mock.get(
+        f"{BASE_URL}/organizations/{ORG_ID}/sessions/devin-test-session",
+        headers__contains={"Authorization": "Bearer test-api-key"},
+    ).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "session_id": "devin-test-session",
+                "status": "running",
+                "status_detail": "finished",
+            },
+        )
+    )
+    respx_mock.get(
+        f"{BASE_URL}/organizations/{ORG_ID}/sessions/devin-test-session/messages",
+        headers__contains={"Authorization": "Bearer test-api-key"},
+    ).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "items": [
+                    {
+                        "event_id": "evt-3",
+                        "source": "devin",
+                        "message": "Here is the follow-up answer.",
+                        "created_at": 2000,
+                    },
+                ],
+                "end_cursor": "cursor-2",
+                "has_next_page": False,
+            },
+        )
+    )
+
+    sut = DevinModel()
+    prompt = MagicMock()
+    prompt.prompt = "Follow up question"
+    prompt.options.debug = False
+
+    prev_response = MagicMock()
+    prev_response.response_json = {
+        "session_id": "devin-test-session",
+        "end_cursor": "cursor-1",
+    }
+    conversation = MagicMock()
+    conversation.responses = [prev_response]
+
+    response = MagicMock()
+
+    actual = list(
+        sut.execute(
+            prompt,
+            stream=False,
+            response=response,
+            conversation=conversation,
+            key="test-api-key",
+        )
+    )
+
+    assert actual == ["Here is the follow-up answer."]
+    assert response.response_json == {
+        "session_id": "devin-test-session",
+        "end_cursor": "cursor-2",
+    }
+
+
+@respx.mock(assert_all_called=True, assert_all_mocked=True)
+def test_continue_conversation_uses_previous_cursor(monkeypatch, respx_mock):
+    monkeypatch.setenv("LLM_DEVIN_ORG_ID", ORG_ID)
+
+    respx_mock.post(
+        f"{BASE_URL}/organizations/{ORG_ID}/sessions/devin-test-session/messages",
+        headers__contains={"Authorization": "Bearer test-api-key"},
+        json__eq={"message": "Another question"},
+    ).mock(
+        return_value=httpx.Response(200, json={})
+    )
+    respx_mock.get(
+        f"{BASE_URL}/organizations/{ORG_ID}/sessions/devin-test-session",
+        headers__contains={"Authorization": "Bearer test-api-key"},
+    ).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "session_id": "devin-test-session",
+                "status": "running",
+                "status_detail": "finished",
+            },
+        )
+    )
+    respx_mock.get(
+        f"{BASE_URL}/organizations/{ORG_ID}/sessions/devin-test-session/messages",
+        headers__contains={"Authorization": "Bearer test-api-key"},
+        params__contains={"after": "cursor-prev"},
+    ).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "items": [
+                    {
+                        "event_id": "evt-5",
+                        "source": "devin",
+                        "message": "Response after cursor",
+                        "created_at": 3000,
+                    },
+                ],
+                "end_cursor": "cursor-new",
+                "has_next_page": False,
+            },
+        )
+    )
+
+    sut = DevinModel()
+    prompt = MagicMock()
+    prompt.prompt = "Another question"
+    prompt.options.debug = False
+
+    prev_response = MagicMock()
+    prev_response.response_json = {
+        "session_id": "devin-test-session",
+        "end_cursor": "cursor-prev",
+    }
+    conversation = MagicMock()
+    conversation.responses = [prev_response]
+
+    response = MagicMock()
+
+    actual = list(
+        sut.execute(
+            prompt,
+            stream=False,
+            response=response,
+            conversation=conversation,
+            key="test-api-key",
+        )
+    )
+
+    assert actual == ["Response after cursor"]

--- a/tests/test_devin.py
+++ b/tests/test_devin.py
@@ -900,3 +900,42 @@ def test_continue_conversation_invalid_session_raises_model_error(
                 key="test-api-key",
             )
         )
+
+
+@respx.mock(assert_all_called=True, assert_all_mocked=True)
+def test_continue_conversation_server_error_is_reraised(
+    monkeypatch, respx_mock
+):
+    monkeypatch.setenv("LLM_DEVIN_ORG_ID", ORG_ID)
+
+    respx_mock.post(
+        f"{BASE_URL}/organizations/{ORG_ID}/sessions/devin-test-session/messages",
+        headers__contains={"Authorization": "Bearer test-api-key"},
+        json__eq={"message": "Follow up"},
+    ).mock(
+        return_value=httpx.Response(500, json={"error": "internal server error"})
+    )
+
+    sut = DevinModel()
+    prompt = MagicMock()
+    prompt.prompt = "Follow up"
+    prompt.options.debug = False
+
+    prev_response = MagicMock()
+    prev_response.response_json = {
+        "session_id": "devin-test-session",
+        "end_cursor": "cursor-old",
+    }
+    conversation = MagicMock()
+    conversation.responses = [prev_response]
+
+    with pytest.raises(httpx.HTTPStatusError):
+        list(
+            sut.execute(
+                prompt,
+                stream=False,
+                response=MagicMock(),
+                conversation=conversation,
+                key="test-api-key",
+            )
+        )


### PR DESCRIPTION
## Summary

Closes #15

`llm -c` (continue conversation) now works with the `devin` model. Previously, every `execute()` call created a new Devin session, ignoring the `conversation` parameter. Now:

- **New session** (no conversation): Creates a session via `POST .../sessions` as before.
- **Continue session** (`llm -c`): Retrieves `session_id` from the previous response's `response_json` and sends a message to the existing session via `POST .../sessions/{devin_id}/messages`.
- **Cursor reuse**: Stores `end_cursor` in `response_json` so continuation polls only skip already-seen messages.
- **Error handling**: If the stored session is invalid/expired (404/410), raises `llm.ModelError` with a clear message. Other HTTP errors (401, 429, 500, etc.) are re-raised as-is.

### Changes
- `_devin.py`: Added `_get_previous_session_id()` helper. Branched `_execute()` logic based on whether a previous session exists. Set `response.response_json` with `session_id` and `end_cursor` after polling completes. Wrapped send-message call with targeted error handling for 404/410.
- `tests/test_devin.py`: Added 5 tests:
  - `test_new_session_stores_session_id` — verifies `response_json` is set on new sessions
  - `test_continue_conversation` — verifies send-message endpoint is called (not create-session) and new messages are yielded
  - `test_continue_conversation_uses_previous_cursor` — verifies the `after` cursor param is passed from previous `end_cursor`
  - `test_continue_conversation_invalid_session_raises_model_error` — verifies clear error on 404 (deleted/expired sessions)
  - `test_continue_conversation_server_error_is_reraised` — verifies 500 errors bubble up as `httpx.HTTPStatusError`

## Review & Testing Checklist for Human
- [x] Verify `llm -m devin "prompt"` followed by `llm -c "follow up"` sends to the same Devin session (check Devin URL output)
- [ ] Verify `response_json` is correctly persisted in llm's SQLite log (`llm logs -n 1 --json` should show `session_id` and `end_cursor`)
- [ ] Verify error handling when a stored `session_id` refers to a deleted/invalid session

### Notes
- The `_get_previous_session_id` helper uses `getattr` for `responses` to safely handle both `None` conversation and conversation objects without responses.
- `llm chat -m devin` should also benefit from this change since it uses the same conversation mechanism.

Link to Devin session: https://app.devin.ai/sessions/0ddce17712044c73872a424353b4cf0c
Requested by: @ftnext
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ftnext/llm-devin/pull/16" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
