### PR TITLE
Document `llm chat` and `llm -c` usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ export LLM_DEVIN_ORG_ID=your_org_id_here
 llm -m devin "Hello, Devin"
 ```
 
-Continue a conversation with `llm -c`:
+Continue that Devin conversation with `llm -c` immediately after the previous command, or specify the model explicitly:
 
 ```bash
-llm -c "Follow-up message"
+llm -m devin -c "Follow-up message"
 ```
 
 Start an interactive chat session:

--- a/README.md
+++ b/README.md
@@ -29,6 +29,18 @@ export LLM_DEVIN_ORG_ID=your_org_id_here
 llm -m devin "Hello, Devin"
 ```
 
+Continue a conversation with `llm -c`:
+
+```bash
+llm -c "Follow-up message"
+```
+
+Start an interactive chat session:
+
+```bash
+llm chat -m devin
+```
+
 ### DeepWiki
 
 ```bash


### PR DESCRIPTION
## Summary

Add documentation for `llm -c` (continue conversation) and `llm chat -m devin` (interactive chat) to the README's Devin API usage section.

Both features are already supported by the existing conversation handling logic in `DevinModel._get_previous_session_id()`.

The `llm -c` example uses `-m devin` explicitly to avoid confusion when the user has run other models in between.

## Review & Testing Checklist for Human
- [ ] Verify the `llm -m devin -c` and `llm chat -m devin` examples work as documented

### Notes
Documentation-only change, no code modifications.

Link to Devin session: https://app.devin.ai/sessions/127181ce74cf40f6b78b327a86a406e8
Requested by: @ftnext
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ftnext/llm-devin/pull/17" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
