### PR TITLE
Fix `--continue` re-outputting previous messages

### DIFF
--- a/llm_devin/_devin.py
+++ b/llm_devin/_devin.py
@@ -113,9 +113,12 @@ class DevinModel(llm.KeyModel):
                 prev_cursor = prev_response_json.get("end_cursor")
             poll_state: dict = {"cursor": prev_cursor}
 
-            self._collect_existing_event_ids(
-                headers, org_id, session_id, poll_state, seen_event_ids,
-            )
+            try:
+                self._collect_existing_event_ids(
+                    headers, org_id, session_id, poll_state, seen_event_ids,
+                )
+            except (httpx.RequestError, httpx.HTTPStatusError):
+                pass
 
             try:
                 send_message_response = httpx.post(

--- a/llm_devin/_devin.py
+++ b/llm_devin/_devin.py
@@ -147,6 +147,11 @@ class DevinModel(llm.KeyModel):
 
         seen_event_ids: set[str] = set()
 
+        if previous_session_id is not None:
+            self._collect_existing_event_ids(
+                headers, org_id, session_id, poll_state, seen_event_ids,
+            )
+
         devin_messages: list[str] = []
         while True:
             try:
@@ -179,6 +184,40 @@ class DevinModel(llm.KeyModel):
             "session_id": session_id,
             "end_cursor": poll_state["cursor"],
         }
+
+    def _collect_existing_event_ids(
+        self, headers, org_id, session_id, poll_state, seen_event_ids,
+    ):
+        cursor = poll_state["cursor"]
+        while True:
+            params = {}
+            if cursor is not None:
+                params["after"] = cursor
+            messages_response = httpx.get(
+                f"{self.BASE_URL}/organizations/{org_id}/sessions/{session_id}/messages",
+                headers=headers,
+                params=params,
+                timeout=TIMEOUT,
+            )
+            messages_response.raise_for_status()
+            data = messages_response.json()
+            logger.debug(
+                "collect existing messages response",
+                extra={"data": data},
+            )
+            for item in data["items"]:
+                seen_event_ids.add(item["event_id"])
+            has_next_page = data.get("has_next_page")
+            new_cursor = data.get("end_cursor")
+            if has_next_page:
+                if new_cursor is None:
+                    break
+                cursor = new_cursor
+                continue
+            if new_cursor is not None:
+                cursor = new_cursor
+                poll_state["cursor"] = cursor
+            break
 
     def _get_session(self, headers, org_id, session_id):
         session_response = httpx.get(

--- a/llm_devin/_devin.py
+++ b/llm_devin/_devin.py
@@ -219,10 +219,11 @@ class DevinModel(llm.KeyModel):
                         " without an end_cursor"
                     )
                 cursor = new_cursor
+                poll_state["cursor"] = cursor
                 continue
             if new_cursor is not None:
                 cursor = new_cursor
-                poll_state["cursor"] = cursor
+            poll_state["cursor"] = cursor
             break
 
     def _get_session(self, headers, org_id, session_id):

--- a/llm_devin/_devin.py
+++ b/llm_devin/_devin.py
@@ -99,11 +99,24 @@ class DevinModel(llm.KeyModel):
 
         previous_session_id = self._get_previous_session_id(conversation)
 
+        seen_event_ids: set[str] = set()
+
         if previous_session_id is not None:
             session_id = previous_session_id
             logger.debug(
                 "Continuing session %s", session_id,
             )
+
+            prev_cursor = None
+            prev_response_json = conversation.responses[-1].response_json
+            if isinstance(prev_response_json, dict):
+                prev_cursor = prev_response_json.get("end_cursor")
+            poll_state: dict = {"cursor": prev_cursor}
+
+            self._collect_existing_event_ids(
+                headers, org_id, session_id, poll_state, seen_event_ids,
+            )
+
             try:
                 send_message_response = httpx.post(
                     f"{self.BASE_URL}/organizations/{org_id}/sessions/{session_id}/messages",
@@ -119,12 +132,6 @@ class DevinModel(llm.KeyModel):
                         "Please start a new conversation."
                     ) from ex
                 raise
-
-            prev_cursor = None
-            prev_response_json = conversation.responses[-1].response_json
-            if isinstance(prev_response_json, dict):
-                prev_cursor = prev_response_json.get("end_cursor")
-            poll_state: dict = {"cursor": prev_cursor}
         else:
             request_json = {"prompt": prompt.prompt}
             logger.debug("Request JSON: %s", request_json)
@@ -144,13 +151,6 @@ class DevinModel(llm.KeyModel):
             session_id = create_session_data["session_id"]
             print_immediately("Devin URL:", create_session_data["url"])
             poll_state = {"cursor": None}
-
-        seen_event_ids: set[str] = set()
-
-        if previous_session_id is not None:
-            self._collect_existing_event_ids(
-                headers, org_id, session_id, poll_state, seen_event_ids,
-            )
 
         devin_messages: list[str] = []
         while True:
@@ -211,7 +211,10 @@ class DevinModel(llm.KeyModel):
             new_cursor = data.get("end_cursor")
             if has_next_page:
                 if new_cursor is None:
-                    break
+                    raise llm.ModelError(
+                        "messages pagination indicated another page"
+                        " without an end_cursor"
+                    )
                 cursor = new_cursor
                 continue
             if new_cursor is not None:

--- a/tests/test_devin.py
+++ b/tests/test_devin.py
@@ -918,6 +918,20 @@ def test_continue_conversation_invalid_session_raises_model_error(
 ):
     monkeypatch.setenv("LLM_DEVIN_ORG_ID", ORG_ID)
 
+    respx_mock.get(
+        f"{BASE_URL}/organizations/{ORG_ID}/sessions/devin-deleted-session/messages",
+        headers__contains={"Authorization": "Bearer test-api-key"},
+        params__contains={"after": "cursor-old"},
+    ).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "items": [],
+                "end_cursor": "cursor-old",
+                "has_next_page": False,
+            },
+        )
+    )
     respx_mock.post(
         f"{BASE_URL}/organizations/{ORG_ID}/sessions/devin-deleted-session/messages",
         headers__contains={"Authorization": "Bearer test-api-key"},
@@ -960,6 +974,20 @@ def test_continue_conversation_server_error_is_reraised(
 ):
     monkeypatch.setenv("LLM_DEVIN_ORG_ID", ORG_ID)
 
+    respx_mock.get(
+        f"{BASE_URL}/organizations/{ORG_ID}/sessions/devin-test-session/messages",
+        headers__contains={"Authorization": "Bearer test-api-key"},
+        params__contains={"after": "cursor-old"},
+    ).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "items": [],
+                "end_cursor": "cursor-old",
+                "has_next_page": False,
+            },
+        )
+    )
     respx_mock.post(
         f"{BASE_URL}/organizations/{ORG_ID}/sessions/devin-test-session/messages",
         headers__contains={"Authorization": "Bearer test-api-key"},

--- a/tests/test_devin.py
+++ b/tests/test_devin.py
@@ -1132,3 +1132,76 @@ def test_continue_conversation_null_end_cursor_skips_old_messages(
     )
 
     assert actual == ["New follow-up answer"]
+
+    messages_gets = [
+        c for c in respx_mock.calls if c.request.method == "GET"
+        and "/messages" in str(c.request.url)
+    ]
+    messages_post = [
+        c for c in respx_mock.calls if c.request.method == "POST"
+        and "/messages" in str(c.request.url)
+    ]
+    assert len(messages_gets) >= 1
+    assert len(messages_post) == 1
+    first_get_index = respx_mock.calls.call_count
+    post_index = respx_mock.calls.call_count
+    for i, call in enumerate(respx_mock.calls):
+        url = str(call.request.url)
+        if call.request.method == "GET" and "/messages" in url:
+            first_get_index = min(first_get_index, i)
+        if call.request.method == "POST" and "/messages" in url:
+            post_index = min(post_index, i)
+    assert first_get_index < post_index
+
+
+@respx.mock(assert_all_called=True, assert_all_mocked=True)
+def test_collect_existing_event_ids_pagination_error(monkeypatch, respx_mock):
+    monkeypatch.setenv("LLM_DEVIN_ORG_ID", ORG_ID)
+
+    respx_mock.get(
+        f"{BASE_URL}/organizations/{ORG_ID}/sessions/devin-test-session/messages",
+        headers__contains={"Authorization": "Bearer test-api-key"},
+    ).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "items": [
+                    {
+                        "event_id": "evt-1",
+                        "source": "devin",
+                        "message": "Old",
+                        "created_at": 1000,
+                    },
+                ],
+                "end_cursor": None,
+                "has_next_page": True,
+            },
+        )
+    )
+
+    sut = DevinModel()
+    prompt = MagicMock()
+    prompt.prompt = "Follow up"
+    prompt.options.debug = False
+
+    prev_response = MagicMock()
+    prev_response.response_json = {
+        "session_id": "devin-test-session",
+        "end_cursor": None,
+    }
+    conversation = MagicMock()
+    conversation.responses = [prev_response]
+
+    with pytest.raises(
+        llm.ModelError,
+        match="messages pagination indicated another page without an end_cursor",
+    ):
+        list(
+            sut.execute(
+                prompt,
+                stream=False,
+                response=MagicMock(),
+                conversation=conversation,
+                key="test-api-key",
+            )
+        )

--- a/tests/test_devin.py
+++ b/tests/test_devin.py
@@ -729,26 +729,58 @@ def test_continue_conversation(monkeypatch, respx_mock):
             },
         )
     )
+    prefetch_response = httpx.Response(
+        200,
+        json={
+            "items": [
+                {
+                    "event_id": "evt-1",
+                    "source": "user",
+                    "message": "Hello",
+                    "created_at": 1000,
+                },
+                {
+                    "event_id": "evt-2",
+                    "source": "devin",
+                    "message": "Previous answer",
+                    "created_at": 1001,
+                },
+            ],
+            "end_cursor": "cursor-1",
+            "has_next_page": False,
+        },
+    )
+    poll_response = httpx.Response(
+        200,
+        json={
+            "items": [
+                {
+                    "event_id": "evt-1",
+                    "source": "user",
+                    "message": "Hello",
+                    "created_at": 1000,
+                },
+                {
+                    "event_id": "evt-2",
+                    "source": "devin",
+                    "message": "Previous answer",
+                    "created_at": 1001,
+                },
+                {
+                    "event_id": "evt-3",
+                    "source": "devin",
+                    "message": "Here is the follow-up answer.",
+                    "created_at": 2000,
+                },
+            ],
+            "end_cursor": "cursor-2",
+            "has_next_page": False,
+        },
+    )
     respx_mock.get(
         f"{BASE_URL}/organizations/{ORG_ID}/sessions/devin-test-session/messages",
         headers__contains={"Authorization": "Bearer test-api-key"},
-    ).mock(
-        return_value=httpx.Response(
-            200,
-            json={
-                "items": [
-                    {
-                        "event_id": "evt-3",
-                        "source": "devin",
-                        "message": "Here is the follow-up answer.",
-                        "created_at": 2000,
-                    },
-                ],
-                "end_cursor": "cursor-2",
-                "has_next_page": False,
-            },
-        )
-    )
+    ).mock(side_effect=[prefetch_response, poll_response])
 
     sut = DevinModel()
     prompt = MagicMock()
@@ -806,27 +838,47 @@ def test_continue_conversation_uses_previous_cursor(monkeypatch, respx_mock):
             },
         )
     )
+    prefetch_response = httpx.Response(
+        200,
+        json={
+            "items": [
+                {
+                    "event_id": "evt-4",
+                    "source": "devin",
+                    "message": "Old message",
+                    "created_at": 2500,
+                },
+            ],
+            "end_cursor": "cursor-prev",
+            "has_next_page": False,
+        },
+    )
+    poll_response = httpx.Response(
+        200,
+        json={
+            "items": [
+                {
+                    "event_id": "evt-4",
+                    "source": "devin",
+                    "message": "Old message",
+                    "created_at": 2500,
+                },
+                {
+                    "event_id": "evt-5",
+                    "source": "devin",
+                    "message": "Response after cursor",
+                    "created_at": 3000,
+                },
+            ],
+            "end_cursor": "cursor-new",
+            "has_next_page": False,
+        },
+    )
     respx_mock.get(
         f"{BASE_URL}/organizations/{ORG_ID}/sessions/devin-test-session/messages",
         headers__contains={"Authorization": "Bearer test-api-key"},
         params__contains={"after": "cursor-prev"},
-    ).mock(
-        return_value=httpx.Response(
-            200,
-            json={
-                "items": [
-                    {
-                        "event_id": "evt-5",
-                        "source": "devin",
-                        "message": "Response after cursor",
-                        "created_at": 3000,
-                    },
-                ],
-                "end_cursor": "cursor-new",
-                "has_next_page": False,
-            },
-        )
-    )
+    ).mock(side_effect=[prefetch_response, poll_response])
 
     sut = DevinModel()
     prompt = MagicMock()
@@ -939,3 +991,116 @@ def test_continue_conversation_server_error_is_reraised(
                 key="test-api-key",
             )
         )
+
+
+@respx.mock(assert_all_called=True, assert_all_mocked=True)
+def test_continue_conversation_null_end_cursor_skips_old_messages(
+    monkeypatch, respx_mock
+):
+    monkeypatch.setenv("LLM_DEVIN_ORG_ID", ORG_ID)
+
+    respx_mock.post(
+        f"{BASE_URL}/organizations/{ORG_ID}/sessions/devin-test-session/messages",
+        headers__contains={"Authorization": "Bearer test-api-key"},
+        json__eq={"message": "Follow up"},
+    ).mock(
+        return_value=httpx.Response(200, json={})
+    )
+    respx_mock.get(
+        f"{BASE_URL}/organizations/{ORG_ID}/sessions/devin-test-session",
+        headers__contains={"Authorization": "Bearer test-api-key"},
+    ).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "session_id": "devin-test-session",
+                "status": "running",
+                "status_detail": "finished",
+            },
+        )
+    )
+    prefetch_response = httpx.Response(
+        200,
+        json={
+            "items": [
+                {
+                    "event_id": "evt-1",
+                    "source": "user",
+                    "message": "Hello",
+                    "created_at": 1000,
+                },
+                {
+                    "event_id": "evt-2",
+                    "source": "devin",
+                    "message": "Previous answer that should NOT appear again",
+                    "created_at": 1001,
+                },
+            ],
+            "end_cursor": None,
+            "has_next_page": False,
+        },
+    )
+    poll_response = httpx.Response(
+        200,
+        json={
+            "items": [
+                {
+                    "event_id": "evt-1",
+                    "source": "user",
+                    "message": "Hello",
+                    "created_at": 1000,
+                },
+                {
+                    "event_id": "evt-2",
+                    "source": "devin",
+                    "message": "Previous answer that should NOT appear again",
+                    "created_at": 1001,
+                },
+                {
+                    "event_id": "evt-3",
+                    "source": "user",
+                    "message": "Follow up",
+                    "created_at": 2000,
+                },
+                {
+                    "event_id": "evt-4",
+                    "source": "devin",
+                    "message": "New follow-up answer",
+                    "created_at": 2001,
+                },
+            ],
+            "end_cursor": None,
+            "has_next_page": False,
+        },
+    )
+    respx_mock.get(
+        f"{BASE_URL}/organizations/{ORG_ID}/sessions/devin-test-session/messages",
+        headers__contains={"Authorization": "Bearer test-api-key"},
+    ).mock(side_effect=[prefetch_response, poll_response])
+
+    sut = DevinModel()
+    prompt = MagicMock()
+    prompt.prompt = "Follow up"
+    prompt.options.debug = False
+
+    prev_response = MagicMock()
+    prev_response.response_json = {
+        "session_id": "devin-test-session",
+        "end_cursor": None,
+    }
+    conversation = MagicMock()
+    conversation.responses = [prev_response]
+
+    response = MagicMock()
+
+    actual = list(
+        sut.execute(
+            prompt,
+            stream=False,
+            response=response,
+            conversation=conversation,
+            key="test-api-key",
+        )
+    )
+
+    assert actual == ["New follow-up answer"]


### PR DESCRIPTION
## Summary

Fixes a bug where `llm -m devin '...' --continue` would re-output all previous messages before showing the new response.

**Root cause**: The Devin messages API returns `end_cursor: null` when `has_next_page` is `false`. On continuation, `prev_cursor` was `None`, so no `after` parameter was sent to the messages endpoint — causing it to return ALL messages from the session start. Since `seen_event_ids` was a fresh empty set each call, old messages were yielded again.

**Fix**: Added `_collect_existing_event_ids()` which pre-fetches existing messages **before** sending the new message to populate `seen_event_ids`, ensuring only truly new messages are yielded. This also avoids a race condition where a fast Devin response could be included in a post-POST prefetch.

**Changes**:
- `_devin.py`: Added `_collect_existing_event_ids()` method; call it before POST when continuing a session. Raises `llm.ModelError` on inconsistent pagination (matching `_drain_messages()` behavior).
- `test_devin.py`: Updated existing continuation tests to mock the prefetch call; added `test_continue_conversation_null_end_cursor_skips_old_messages` which directly reproduces the bug scenario.

## Review & Testing Checklist for Human

- [ ] Run `llm -m devin 'prompt'` followed by `llm -m devin 'follow up' --continue` and verify the second call does NOT re-output the first response
- [ ] Verify `llm logs -n 2 --json` shows both entries use the same `session_id`

### Notes

Related to PR #16 which added `--continue` support. The bug was discovered during end-to-end testing where `end_cursor` from the real Devin API was consistently `null`.

Link to Devin session: https://app.devin.ai/sessions/0ddce17712044c73872a424353b4cf0c
Requested by: @ftnext
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ftnext/llm-devin/pull/18" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
